### PR TITLE
Enable Lua ‌5.4 and test against array of Lua versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Tests
+on: [push, pull_request]
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        luaVersion: ["5.4", "5.3", "5.2", "5.1", "luajit", "luajit-openresty"]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Lua
+      uses: leafo/gh-actions-lua@v6
+      with:
+        luaVersion: ${{ matrix.luaVersion }}
+    - name: Setup Lua Rocks
+      uses: leafo/gh-actions-luarocks@v2
+    - name: Setup dependencies
+      run: |
+        luarocks install --only-deps luaepnf-scm-0.rockspec
+    - name: Run Tests
+      run: |
+        cd tests
+        for testf in *.lua; do
+          lua $testf
+        done

--- a/luaepnf-scm-0.rockspec
+++ b/luaepnf-scm-0.rockspec
@@ -13,7 +13,7 @@ description = {
   license = "MIT"
 }
 dependencies = {
-  "lua >= 5.1, < 5.4",
+  "lua >= 5.1",
   "lpeg >= 0.8"
 }
 build = {


### PR DESCRIPTION
Closes #4. It looks like everything works fine in Lua 5.4, you just have to let it happen.

Besides removing the upper bound on the version restriction this adds a CI job that tests this against a whole array of Lua versions. Preview the output [from my fork here](https://github.com/alerque/lua-luaepnf/runs/836817094?check_suite_focus=true).